### PR TITLE
feat: add dark/light mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,172 +1,287 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    
-    <!-- This add a icon on the browres tab  -->
-    <link rel="icon" href="./assets/logo.png">
-    <title>Spotify - Web Player: Music for everyone</title>
-    <link rel="stylesheet" href="style.css">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link
+    rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css"
+    integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg=="
+    crossorigin="anonymous"
+    referrerpolicy="no-referrer"
+  />
+  <link rel="icon" href="./assets/logo.png" />
+  <title>Spotify - Web Player: Music for everyone</title>
+  <link rel="stylesheet" href="style.css" />
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
-    
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@30,300,0,0" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
 </head>
 <body>
-
-    <div class="main">
-        <div class="sidebar">
-            <div class="nav">
-                <div class="nav-option active">
-                    <i class="fa-solid fa-house"></i>
-                    <a href="#" role="button" aria-label="Go to Home">Home</a>
-                </div>
-                <div class="nav-option">
-                    <i class="fa-solid fa-magnifying-glass"></i>
-                    <a href="#" role="button" aria-label="Open Search">Search</a>
-                </div>
-            </div>
-            <div class="library">
-                <div class="library-header">
-                    <div class="lib-option nav-option">
-                        <i class="fa-solid fa-lines-leaning"></i>
-                        <span>Your Library</span>
-                    </div> 
-                    <div class="library-actions">
-                        <i class="fa-solid fa-plus" role="button" aria-label="Create playlist" tabindex="0"></i>
-                    </div>
-                </div>
-                <div class="library-filter">
-                    <button class="filter-btn active">Playlists</button>
-                    <button class="filter-btn">Artists</button>
-                </div>
-                <div class="library-content">
-                    <div class="playlist-item">
-                        <div class="playlist-cover">
-                            <i class="fa-solid fa-heart"></i>
-                        </div>
-                        <div class="playlist-info">
-                            <p class="playlist-name">Liked Songs</p>
-                            <p class="playlist-meta">67 songs</p>
-                        </div>
-                    </div>
-                </div>
-            </div>
+  <div class="main">
+    <!-- SIDEBAR -->
+    <div class="sidebar">
+      <div class="nav">
+        <div class="nav-option active">
+          <i class="fa-solid fa-house"></i>
+          <a href="#">Home</a>
         </div>
-        <div class="main-content">
-            <div class="sticky-nav">
-                <div class="sticky-nav-icons">
-                    <img src="./assets/backward_icon.png" alt="Go back" role="button" tabindex="0">
-                    <img src="./assets/forward_icon.png" class="hide" alt="Go forward" role="button" tabindex="0">
-                </div>
-                <div class="sticky-nav-options">
-                    <button class="badge nav-item hide" aria-label="Explore Premium features">Explore Premium</button>
-                    <button class="badge nav-item dark-badge" aria-label="Install Spotify App"><i class="fa-regular fa-circle-down" style="margin-right: 5px;"></i>Install App</button>
-                    <i class="fa-regular fa-user" role="button" aria-label="User profile" tabindex="0"></i>
-                </div>
-               </div>
-            <h2>Recently Played</h2>
-            <div class="cards-container">
-                <div class="card">
-                    <img src="assets/card1img.jpg" class="card-img" alt="Top 50 Global playlist cover">
-                    <p class="card-title">Top 50 - Global</p>
-                    <p class="card-info">Your daily update of the most played...</p>
-                </div>
-            </div>
-
-
-            <h2>Trending now near you</h2>
-            <div class="cards-container">
-                <div class="card">
-                    <img src="assets/card2img.jpg" class="card-img">
-                    <p class="card-title">Top 50 - Global</p>
-                    <p class="card-info">Your daily update of the most played...</p>
-                </div>
-                <div class="card">
-                    <img src="assets/card3img.jpg" class="card-img">
-                    <p class="card-title">Top 50 - Global</p>
-                    <p class="card-info">Your daily update of the most played...</p>
-                </div>
-                <div class="card">
-                    <img src="assets/card4img.jpg" class="card-img">
-                    <p class="card-title">Top 50 - Global</p>
-                    <p class="card-info">Your daily update of the most played...</p>
-                </div>
-                <div class="card">
-                    <img src="assets/card2img.jpg" class="card-img">
-                    <p class="card-title">Top 50 - Global</p>
-                    <p class="card-info">Your daily update of the most played...</p>
-                </div>
-                <div class="card">
-                    <img src="assets/card4img.jpg" class="card-img">
-                    <p class="card-title">Top 50 - Global</p>
-                    <p class="card-info">Your daily update of the most played...</p>
-                </div>
-            </div>
-
-            <h2>Featured Charts</h2>
-            <div class="cards-container">
-                <div class="card">
-                    <img src="assets/card5img.jpg" class="card-img">
-                    <p class="card-title">Top 50 - Global</p>
-                    <p class="card-info">Your daily update of the most played...</p>
-                </div>
-                <div class="card">
-                    <img src="assets/card6img.jpg" class="card-img">
-                    <p class="card-title">Top 50 - Global</p>
-                    <p class="card-info">Your daily update of the most played...</p>
-                </div>
-                <div class="card">
-                    <img src="assets/card5img.jpg" class="card-img">
-                    <p class="card-title">Top 50 - Global</p>
-                    <p class="card-info">Your daily update of the most played...</p>
-                </div>
-            </div>
-           <div class="footer">
-            <div class="line"></div>
-           </div>
+        <div class="nav-option">
+          <i class="fa-solid fa-magnifying-glass"></i>
+          <a href="#">Search</a>
         </div>
-        <div class="music-player">
-            <div class="album">
-                <img src="assets/card2img.jpg" class="curr-album-playing" alt="Now playing: Daylight by David Kushner">
-                <div class="album-album-artist-name">
-                    <p class="curr-song-name">Daylight</p> 
-                    <p class="curr-song-artist">David Kushner</p>
-                </div>
-                <div class="icon-album">
-                <i class="fa-regular fa-heart heart-icon" role="button" aria-label="Like this song" tabindex="0"></i>
-                <i class="fa-solid fa-download download-icon" role="button" aria-label="Download song" tabindex="0"></i>
-                </div>
-            </div>
+      </div>
 
-            <div class="player">
-                <div class="player-control">
-                    <img src="./assets/player_icon1.png" class="player-control-icon" alt="Shuffle" role="button" tabindex="0">
-                    <img src="./assets/player_icon2.png" class="player-control-icon" alt="Previous track" role="button" tabindex="0">
-                    <img src="./assets/player_icon3.png" class="player-control-icon" style="opacity: 1; height: 2rem;" alt="Play/Pause" role="button" tabindex="0">
-                    <img src="./assets/player_icon4.png" class="player-control-icon" alt="Next track" role="button" tabindex="0">
-                    <img src="./assets/player_icon5.png" class="player-control-icon" alt="Repeat" role="button" tabindex="0">
-                </div>
-                <div class="space-btwn-playback"></div>
-                <div class="playback-bar">
-                    <span class="curr-time">00:00</span>
-                    <input type="range" min="0" max="100" step="1" class="progress-bar" aria-label="Song progress">
-                    <span class="tot-time">3:33</span>
-                </div>
-            </div>
-            <div class="controls">
-                <span class="material-symbols-outlined" role="button" aria-label="Queue" tabindex="0">slideshow</span>
-                <span class="material-symbols-outlined" role="button" aria-label="Connect to device" tabindex="0">music_cast</span>
-                <span class="material-symbols-outlined" role="button" aria-label="Show lyrics" tabindex="0">lyrics </span>
-                <span class="material-symbols-outlined" role="button" aria-label="Audio settings" tabindex="0">discover_tune</span>
-                    <span class="material-symbols-outlined" role="button" aria-label="Volume" tabindex="0">volume_up</span>
-                <input type="range" min="0" max="100" step="1" class="volume" aria-label="Volume control">
-            </div>
+      <div class="library">
+        <div class="library-header">
+          <div class="lib-option nav-option">
+            <i class="fa-solid fa-book"></i>
+            <span>Your Library</span>
+          </div>
+          <div class="library-actions">
+            <i class="fa-solid fa-plus" role="button" aria-label="Create playlist"></i>
+          </div>
         </div>
+
+        <div class="library-filter">
+          <button class="filter-btn active">Playlists</button>
+          <button class="filter-btn">Artists</button>
+          <button class="filter-btn">Albums</button>
+        </div>
+
+        <div class="library-content">
+          <div class="playlist-item">
+            <div class="playlist-cover">
+              <i class="fa-solid fa-heart"></i>
+            </div>
+            <div class="playlist-info">
+              <p class="playlist-name">Liked Songs</p>
+              <p class="playlist-meta">Playlist • 67 songs</p>
+            </div>
+          </div>
+
+          <div class="playlist-item">
+            <div class="playlist-cover" style="background: linear-gradient(135deg, #ee0979, #ff6a00);">
+              <i class="fa-solid fa-music"></i>
+            </div>
+            <div class="playlist-info">
+              <p class="playlist-name">My Playlist #1</p>
+              <p class="playlist-meta">Playlist • 42 songs</p>
+            </div>
+          </div>
+
+          <div class="playlist-item">
+            <div class="playlist-cover" style="background: linear-gradient(135deg, #667eea, #764ba2);">
+              <i class="fa-solid fa-guitar"></i>
+            </div>
+            <div class="playlist-info">
+              <p class="playlist-name">Rock Classics</p>
+              <p class="playlist-meta">Playlist • 89 songs</p>
+            </div>
+          </div>
+
+          <div class="playlist-item">
+            <div class="playlist-cover" style="background: linear-gradient(135deg, #f093fb, #f5576c);">
+              <i class="fa-solid fa-fire"></i>
+            </div>
+            <div class="playlist-info">
+              <p class="playlist-name">Workout Mix</p>
+              <p class="playlist-meta">Playlist • 35 songs</p>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
+
+    <!-- MAIN CONTENT -->
+    <div class="main-content">
+      <!-- Top Navigation Bar -->
+<div class="sticky-nav">
+  <div class="sticky-nav-icons">
+    <button class="nav-arrow" aria-label="Go back">
+      <i class="fa-solid fa-chevron-left"></i>
+    </button>
+    <button class="nav-arrow" aria-label="Go forward">
+      <i class="fa-solid fa-chevron-right"></i>
+    </button>
+  </div>
+
+  <div class="sticky-nav-options">
+    <button class="badge nav-item hide">Explore Premium</button>
+    <button class="badge nav-item dark-badge">
+      <i class="fa-regular fa-circle-down" style="margin-right: 5px;"></i>Install App
+    </button>
+
+    <!-- Theme Toggle with Sun Icon -->
+    <button id="theme-toggle" class="badge nav-item theme-btn" aria-label="Toggle theme">
+      <i class="fa-solid fa-sun"></i>
+    </button>
+
+    <!-- Improved User Icon -->
+    <button class="nav-item user-btn" aria-label="User profile">
+     <i class="fa-solid fa-user"></i>
+    </button>
+  </div>
+</div>
+
+
+      <!-- Content Sections -->
+      <h2>Recently Played</h2>
+      <div class="cards-container">
+        <div class="card">
+          <img src="assets/card1img.jpg" class="card-img" alt="Top 50 Global" />
+          <p class="card-title">Top 50 - Global</p>
+          <p class="card-info">Your daily update of the most played...</p>
+        </div>
+        <div class="card">
+          <img src="assets/card2img.jpg" class="card-img" alt="Viral Hits" />
+          <p class="card-title">Viral Hits</p>
+          <p class="card-info">Songs that are trending worldwide</p>
+        </div>
+        <div class="card">
+          <img src="assets/card3img.jpg" class="card-img" alt="Chill Vibes" />
+          <p class="card-title">Chill Vibes</p>
+          <p class="card-info">Relax and unwind with these tracks</p>
+        </div>
+        <div class="card">
+          <img src="assets/card4img.jpg" class="card-img" alt="Discover Weekly" />
+          <p class="card-title">Discover Weekly</p>
+          <p class="card-info">Your personalized playlist</p>
+        </div>
+        <div class="card">
+          <img src="assets/card5img.jpg" class="card-img" alt="Daily Mix 1" />
+          <p class="card-title">Daily Mix 1</p>
+          <p class="card-info">Made for you</p>
+        </div>
+      </div>
+
+      <h2>Trending now near you</h2>
+      <div class="cards-container">
+        <div class="card">
+          <img src="assets/card2img.jpg" class="card-img" alt="Hot Hits India" />
+          <p class="card-title">Hot Hits India</p>
+          <p class="card-info">The most played songs right now</p>
+        </div>
+        <div class="card">
+          <img src="assets/card3img.jpg" class="card-img" alt="Bollywood Jazz" />
+          <p class="card-title">Bollywood Jazz</p>
+          <p class="card-info">Fusion of Bollywood and Jazz</p>
+        </div>
+        <div class="card">
+          <img src="assets/card4img.jpg" class="card-img" alt="Indie India" />
+          <p class="card-title">Indie India</p>
+          <p class="card-info">The best of Indian independent music</p>
+        </div>
+        <div class="card">
+          <img src="assets/card1img.jpg" class="card-img" alt="Desi Hip Hop" />
+          <p class="card-title">Desi Hip Hop</p>
+          <p class="card-info">Hip hop from the streets of India</p>
+        </div>
+        <div class="card">
+          <img src="assets/card6img.jpg" class="card-img" alt="Retro India" />
+          <p class="card-title">Retro India</p>
+          <p class="card-info">Classic hits from the golden era</p>
+        </div>
+      </div>
+
+      <h2>Featured Charts</h2>
+      <div class="cards-container">
+        <div class="card">
+          <img src="assets/card5img.jpg" class="card-img" alt="Top 50 USA" />
+          <p class="card-title">Top 50 - USA</p>
+          <p class="card-info">Most played in United States</p>
+        </div>
+        <div class="card">
+          <img src="assets/card6img.jpg" class="card-img" alt="Top 50 Global" />
+          <p class="card-title">Top 50 - Global</p>
+          <p class="card-info">The world's most played songs</p>
+        </div>
+        <div class="card">
+          <img src="assets/card1img.jpg" class="card-img" alt="Viral 50" />
+          <p class="card-title">Viral 50</p>
+          <p class="card-info">Most viral tracks this week</p>
+        </div>
+        <div class="card">
+          <img src="assets/card2img.jpg" class="card-img" alt="Fresh Finds" />
+          <p class="card-title">Fresh Finds</p>
+          <p class="card-info">New music from emerging artists</p>
+        </div>
+        <div class="card">
+          <img src="assets/card3img.jpg" class="card-img" alt="Trending Now" />
+          <p class="card-title">Trending Now</p>
+          <p class="card-info">What's hot right now</p>
+        </div>
+      </div>
+
+      <div class="footer">
+        <div class="line"></div>
+      </div>
+    </div>
+
+    <!-- MUSIC PLAYER -->
+    <div class="music-player">
+      <!-- Left Section: Now Playing -->
+      <div class="album">
+        <img src="assets/card2img.jpg" class="curr-album-playing" alt="Now playing album cover" />
+        <div class="album-album-artist-name">
+          <p class="curr-song-name">Daylight</p>
+          <p class="curr-song-artist">David Kushner</p>
+        </div>
+        <div class="icon-album">
+          <i class="fa-regular fa-heart heart-icon" role="button" aria-label="Like song"></i>
+          <i class="fa-solid fa-ban download-icon" role="button" aria-label="Block song"></i>
+        </div>
+      </div>
+
+      <!-- Center Section: Playback Controls -->
+      <div class="player">
+        <div class="player-control">
+          <img src="assets/player_icon1.png" class="player-control-icon" alt="Shuffle" role="button" />
+          <img src="assets/player_icon2.png" class="player-control-icon" alt="Previous" role="button" />
+          <img src="assets/player_icon3.png" class="player-control-icon" alt="Play" role="button" style="opacity: 1; height: 2rem;" />
+          <img src="assets/player_icon4.png" class="player-control-icon" alt="Next" role="button" />
+          <img src="assets/player_icon5.png" class="player-control-icon" alt="Repeat" role="button" />
+        </div>
+        <div class="playback-bar">
+          <span class="curr-time">0:00</span>
+          <input type="range" min="0" max="100" value="0" class="progress-bar" aria-label="Seek" />
+          <span class="tot-time">3:33</span>
+        </div>
+      </div>
+
+      <!-- Right Section: Volume Controls -->
+      <div class="controls">
+        <i class="fa-solid fa-list" role="button" aria-label="Queue"></i>
+        <i class="fa-solid fa-desktop" role="button" aria-label="Connect to device"></i>
+        <i class="fa-solid fa-volume-high" role="button" aria-label="Mute"></i>
+        <input type="range" min="0" max="100" value="100" class="volume" aria-label="Volume" />
+        <i class="fa-solid fa-maximize" role="button" aria-label="Full screen"></i>
+      </div>
+    </div>
+  </div>
+
+  <!-- Theme Toggle Script -->
+  <script>
+    const toggleBtn = document.getElementById('theme-toggle');
+    const body = document.body;
+    const icon = toggleBtn.querySelector('i');
+
+    // Apply saved theme on load
+    if (localStorage.getItem('theme') === 'light') {
+      body.classList.add('light-mode');
+      icon.classList.replace('fa-moon', 'fa-sun');
+    }
+
+    toggleBtn.addEventListener('click', () => {
+      const isLight = body.classList.toggle('light-mode');
+      icon.classList.toggle('fa-moon', !isLight);
+      icon.classList.toggle('fa-sun', isLight);
+      localStorage.setItem('theme', isLight ? 'light' : 'dark');
+    });
+  </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -7,58 +7,75 @@
     --spotify-red: #ff0000;
 }
 
+/* Light mode color overrides */
+body.light-mode {
+    --spotify-black: #ffffff;
+    --spotify-dark: #f6f6f6;
+    --spotify-gray: #e8e8e8;
+    --spotify-white: #000000;
+}
+
 body {
     font-family: "Montserrat", serif;
     margin: 0;
     background-color: var(--spotify-black);
     color: var(--spotify-white);
     overflow: hidden;
+    transition: background-color 0.3s ease, color 0.3s ease;
 }
 
-.main{
+.main {
     display: flex;
     height: 100vh;
     padding: 0.5rem;
 }
 
-.sidebar{
+.sidebar {
     background-color: var(--spotify-black);
     width: 340px;
-    border-radius: 1rem; /* 1rem = 16px*/
+    border-radius: 1rem;
     margin-right: 0.5rem;
     height: 489px;
+    transition: background-color 0.3s ease;
 }
 
-.main-content{
+.main-content {
     background-color: var(--spotify-dark);
-    flex: 1; /*It covers the remaining space in screen*/
-    overflow: auto;  /*If needed it gives side scroll bar*/
+    flex: 1;
+    overflow: auto;
     border-radius: 1rem;
     padding: 0 1.5rem 0 1.5rem;
     height: 630px;
+    transition: background-color 0.3s ease;
 }
 
-.music-player{
+.music-player {
     background-color: var(--spotify-black);
     position: fixed;
     bottom: 0px;
     width: 100%;
     height: 78px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    transition: background-color 0.3s ease;
 }
 
-a{
+a {
     text-decoration: none;
     color: var(--spotify-white);
+    transition: color 0.3s ease;
 }
 
-.nav{
+.nav {
     background-color: var(--spotify-dark);
     border-radius: 8px;
     padding: 8px 12px;
     margin-bottom: 8px;
+    transition: background-color 0.3s ease;
 }
 
-.nav-option{
+.nav-option {
     display: flex;
     align-items: center;
     padding: 12px 8px;
@@ -67,38 +84,39 @@ a{
     font-size: 14px;
     font-weight: 700;
     color: #b3b3b3;
-    transition: color 0.3s ease;
+    transition: color 0.3s ease, background-color 0.3s ease;
     cursor: pointer;
 }
 
-.nav-option:hover{
+.nav-option:hover {
     color: var(--spotify-white);
 }
 
-.nav-option.active{
+.nav-option.active {
     color: var(--spotify-white);
 }
 
-.nav-option i{
+.nav-option i {
     font-size: 24px;
     margin-right: 16px;
 }
 
-.nav-option a{
+.nav-option a {
     color: inherit;
     text-decoration: none;
 }
 
-.library{
+.library {
     background-color: var(--spotify-dark);
     border-radius: 8px;
     flex: 1;
     padding: 8px 12px;
     display: flex;
     flex-direction: column;
+    transition: background-color 0.3s ease;
 }
 
-.library-header{
+.library-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -106,24 +124,25 @@ a{
     margin-bottom: 16px;
 }
 
-.library-header .lib-option{
+.library-header .lib-option {
     display: flex;
     align-items: center;
     font-size: 16px;
     font-weight: 700;
     color: #b3b3b3;
+    transition: color 0.3s ease;
 }
 
-.library-header .lib-option:hover{
+.library-header .lib-option:hover {
     color: var(--spotify-white);
 }
 
-.library-header .lib-option i{
+.library-header .lib-option i {
     font-size: 24px;
     margin-right: 12px;
 }
 
-.library-actions i{
+.library-actions i {
     font-size: 16px;
     color: #b3b3b3;
     cursor: pointer;
@@ -132,18 +151,18 @@ a{
     transition: all 0.3s ease;
 }
 
-.library-actions i:hover{
+.library-actions i:hover {
     color: var(--spotify-white);
     background-color: rgba(255, 255, 255, 0.1);
 }
 
-.library-filter{
+.library-filter {
     display: flex;
     gap: 8px;
     margin-bottom: 16px;
 }
 
-.filter-btn{
+.filter-btn {
     background: var(--spotify-gray);
     border: none;
     border-radius: 20px;
@@ -154,16 +173,16 @@ a{
     transition: all 0.3s ease;
 }
 
-.filter-btn:hover{
+.filter-btn:hover {
     background: rgba(255, 255, 255, 0.1);
 }
 
-.filter-btn.active{
+.filter-btn.active {
     background: var(--spotify-white);
     color: var(--spotify-black);
 }
 
-.playlist-item{
+.playlist-item {
     display: flex;
     align-items: center;
     padding: 8px 4px;
@@ -172,11 +191,11 @@ a{
     transition: background-color 0.3s ease;
 }
 
-.playlist-item:hover{
+.playlist-item:hover {
     background-color: rgba(255, 255, 255, 0.1);
 }
 
-.playlist-cover{
+.playlist-cover {
     width: 48px;
     height: 48px;
     background: linear-gradient(135deg, #450af5, #c4efd9);
@@ -187,45 +206,47 @@ a{
     margin-right: 12px;
 }
 
-.playlist-cover i{
+.playlist-cover i {
     color: var(--spotify-white);
     font-size: 20px;
 }
 
-.playlist-info{
+.playlist-info {
     flex: 1;
 }
 
-.playlist-name{
+.playlist-name {
     font-size: 14px;
     font-weight: 600;
     color: var(--spotify-white);
     margin: 0 0 4px 0;
+    transition: color 0.3s ease;
 }
 
-.playlist-meta{
+.playlist-meta {
     font-size: 12px;
     color: #b3b3b3;
     margin: 0;
+    transition: color 0.3s ease;
 }
 
-.options{
+.options {
     display: flex;
     justify-content: space-between;
     align-items: center;
 }
 
-.lib-option img{
+.lib-option img {
     width: 1.25rem;
     height: 1.25rem;
 }
 
-.icons{
+.icons {
     font-size: 1.25rem;
     display: flex;
 }
 
-.icons i{
+.icons i {
     opacity: 0.7;
     margin-right: 1rem;
     padding: 0.5rem;
@@ -233,31 +254,32 @@ a{
     transition: all 0.3s ease;
 }
 
-.icons i:hover{
+.icons i:hover {
     opacity: 1;
     background-color: rgba(255, 255, 255, 0.1);
     transform: scale(1.1);
 }
 
-.box{
+.box {
     height: 8rem;
     background-color: var(--spotify-gray);
     border-radius: 0.75rem;
-    margin: 0.5rem 0  1.75rem 0;
+    margin: 0.5rem 0 1.75rem 0;
     padding: 0.5rem 1rem;
+    transition: background-color 0.3s ease;
 }
 
-.box-p1{
+.box-p1 {
     font-size: 1rem;
     font-weight: 500;
 }
 
-.box-p2{
+.box-p2 {
     font-size: 0.75rem;
     opacity: 0.9;
 }
 
-.badge{
+.badge {
     background-color: var(--spotify-white);
     border: none;
     border-radius: 100px;
@@ -275,43 +297,387 @@ a{
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
 }
 
-.dark-badge{
+.dark-badge {
     background-color: var(--spotify-black);
     color: var(--spotify-white);
 }
 
-.sticky-nav{
+.sticky-nav {
     position: sticky;
     display: flex;
     top: 0;
     background-color: var(--spotify-dark);
     justify-content: space-between;
     align-items: center;
-    padding: 1rem 0 1rem 0; 
+    padding: 1rem 0 1rem 0;
     z-index: 1;
+    transition: background-color 0.3s ease;
 }
 
-.sticky-nav-icons{
+.sticky-nav-icons {
     margin-left: 0.75rem;
 }
 
-.sticky-nav-options{
+.sticky-nav-options {
     display: flex;
     justify-content: center;
     align-items: center;
 }
 
-.nav-item{
+/* ------------------ THEME BUTTON ------------------ */
+.theme-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 1.2rem;
+    color: var(--spotify-white);
+    transition: color 0.3s ease;
+}
+
+.theme-btn:hover {
+    color: var(--spotify-green);
+}
+
+/* ------------------ USER BUTTON ------------------ */
+.user-btn {
+    background-color: var(--spotify-gray);
+    border-radius:100%;       
+    width: 35px;             
+    height: 35px;            
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.3s ease;
+    cursor: pointer;
+}
+
+.user-btn i {
+    font-size: 1.2rem;       
+    color: var(--spotify-white);
+    transition: color 0.3s ease;
+}
+
+.user-btn:hover {
+    background-color: var(--spotify-green);
+    transform: scale(1.1);
+}
+
+.user-btn:hover i {
+    color: var(--spotify-black);  
+}
+
+
+.nav-item {
     margin-right: 1rem;
 }
 
+.card {
+    background-color: var(--spotify-gray);
+    width: 150px;
+    border-radius: 0.5rem;
+    padding: 1rem;
+    margin-left: 1.5rem;
+    margin-top: 1rem;
+    transition: all 0.3s ease;
+}
+
+.cards-container {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.card-img {
+    width: 100%;
+    border-radius: 0.5rem;
+}
+
+.card-title {
+    font-weight: 600;
+    transition: color 0.3s ease;
+}
+
+.card-info {
+    font-size: 0.85rem;
+    opacity: 0.8;
+    transition: color 0.3s ease;
+}
+
+.footer {
+    height: 300px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.line {
+    width: 90%;
+    height: 40%;
+    border-top: 1px solid rgb(255, 255, 255);
+    opacity: 0.4;
+    transition: border-color 0.3s ease;
+}
+
+.album {
+    width: 25%;
+    display: flex;
+    align-items: center;
+    padding-left: 0.5rem;
+}
+
+.curr-album-playing {
+    height: 4rem;
+    border-radius: 0.5rem;
+}
+
+.curr-song-name {
+    font-weight: 500;
+    font-size: 0.9rem;
+    transition: color 0.3s ease;
+}
+
+.curr-song-artist {
+    font-size: 0.7rem;
+    transition: color 0.3s ease;
+}
+
+.album-album-artist-name {
+    padding-left: 0.9rem;
+    line-height: 0.5rem;
+}
+
+.icon-album {
+    padding-left: 1rem;
+    font-size: 1.1rem;
+}
+
+.download-icon {
+    padding-left: 0.5rem;
+}
+
+.heart-icon {
+    transition: color 0.5s
+}
+
+.heart-icon:hover {
+    color: var(--spotify-red);
+}
+
+.player {
+    width: 50%;
+}
+
+.controls {
+    width: 25%;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: center;
+    cursor: default;
+}
+
+.volume {
+    width: 35%;
+    appearance: none;
+    background-color: transparent;
+    cursor: pointer;
+}
+
+.volume::-webkit-slider-runnable-track {
+    background-color: #ddd;
+    border-radius: 100px;
+    height: 0.2rem;
+    transition: background-color 0.3s ease;
+}
+
+.volume::-webkit-slider-thumb {
+    appearance: none;
+    height: 1rem;
+    width: 1rem;
+    background-color: #277443;
+    border-radius: 50%;
+    margin-top: -6px;
+}
+
+.player-control {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.player-control-icon {
+    height: 1rem;
+    margin-left: 1.75rem;
+    opacity: 0.7;
+    transition: all 0.2s ease;
+}
+
+.player-control-icon:hover {
+    opacity: 1;
+    transform: scale(1.05);
+}
+
+.playback-bar {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.progress-bar {
+    width: 70%;
+    appearance: none;
+    background-color: transparent;
+    cursor: pointer;
+}
+
+.progress-bar::-webkit-slider-runnable-track {
+    background-color: #ddd;
+    border-radius: 100px;
+    height: 0.2rem;
+    transition: background-color 0.3s ease;
+}
+
+.progress-bar::-webkit-slider-thumb {
+    appearance: none;
+    height: 1rem;
+    width: 1rem;
+    background-color: #1bd760;
+    border-radius: 50%;
+    margin-top: -6px;
+}
+
+.space-btwn-playback {
+    height: 0.4rem;
+}
+
+/* Focus styles */
+[role="button"]:focus,
+button:focus,
+input:focus {
+    outline: 2px solid var(--spotify-green);
+    outline-offset: 2px;
+}
+
+/* Hover effects */
+[role="button"]:hover {
+    opacity: 1;
+    transform: scale(1.05);
+    transition: all 0.2s ease;
+}
+
+.card:hover {
+    background-color: #2a2a2a;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+/* ============================================
+   LIGHT MODE SPECIFIC STYLES
+   ============================================ */
+
+body.light-mode .nav-option {
+    color: #5a5a5a;
+}
+
+body.light-mode .nav-option:hover,
+body.light-mode .nav-option.active {
+    color: var(--spotify-white);
+}
+
+body.light-mode .library-header .lib-option,
+body.light-mode .library-actions i,
+body.light-mode .icons i {
+    color: #5a5a5a;
+}
+
+body.light-mode .library-header .lib-option:hover,
+body.light-mode .library-actions i:hover,
+body.light-mode .icons i:hover {
+    color: var(--spotify-white);
+}
+
+body.light-mode .playlist-meta,
+body.light-mode .card-info,
+body.light-mode .curr-song-artist {
+    color: #5a5a5a;
+}
+
+body.light-mode .progress-bar::-webkit-slider-runnable-track,
+body.light-mode .volume::-webkit-slider-runnable-track {
+    background-color: #666;
+}
+
+body.light-mode .card:hover {
+    background-color: #d8d8d8;
+}
+
+body.light-mode .filter-btn {
+    color: #000000;
+}
+
+body.light-mode .filter-btn:hover {
+    background: rgba(0, 0, 0, 0.1);
+}
+
+body.light-mode .filter-btn.active {
+    background: var(--spotify-white);
+    color: var(--spotify-black);
+}
+
+body.light-mode #theme-toggle {
+    background-color: var(--spotify-gray);
+    color: var(--spotify-white);
+}
+
+body.light-mode #theme-toggle:hover {
+    background-color: #d0d0d0;
+}
+
+body.light-mode .line {
+    border-top-color: #000000;
+}
+
+body.light-mode .library-actions i:hover {
+    background-color: rgba(0, 0, 0, 0.1);
+}
+
+body.light-mode .icons i:hover {
+    background-color: rgba(0, 0, 0, 0.1);
+}
+
+body.light-mode .playlist-item:hover {
+    background-color: rgba(0, 0, 0, 0.1);
+}
+
+/* Fix badge colors in light mode - swap dark/light behavior */
+body.light-mode .badge {
+    background-color: var(--spotify-white);
+    color: var(--spotify-black);
+}
+
+body.light-mode .dark-badge {
+    background-color: var(--spotify-black);
+    color: var(--spotify-white);
+}
+
+/* Make player control icons visible in light mode */
+body.light-mode .player-control-icon {
+    filter: invert(1);
+}
+
+/* Fix user icon visibility in light mode */
+body.light-mode .user-btn i {
+    color: var(--spotify-white);
+}
+
+/* ============================================
+   RESPONSIVE DESIGN
+   ============================================ */
+
 @media (max-width: 1000px) {
-    .hide{
+    .hide {
         display: none;
     }
 }
 
-/* Mobile responsive design */
 @media (max-width: 768px) {
     .main {
         flex-direction: column;
@@ -370,204 +736,4 @@ a{
     .card-info {
         font-size: 0.7rem;
     }
-}
-
-.card{
-    background-color: var(--spotify-gray);
-    width: 150px;
-    border-radius: 0.5rem;
-    padding: 1rem;
-    margin-left: 1.5rem;
-    margin-top: 1rem;
-}
-
-.cards-container{
-    display: flex;
-    flex-wrap: wrap;
-}
-
-.card-img{
-    width: 100%;
-    border-radius: 0.5rem;
-}
-
-.card-title{
-    font-weight: 600;
-}
-
-.card-info{
-    font-size: 0.85rem;
-    opacity: 0.8;
-}
-
-.footer{
-    height: 300px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.line{
-    width: 90%;
-    height: 40%;
-    border-top: 1px solid rgb(255, 255, 255);
-    opacity: 0.4;
-}
-
-.music-player{
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-}
-
-.album{
-    width: 25%;
-    display: flex;
-    /* justify-content: center; */
-    /* flex-wrap: wrap; */
-    align-items: center;
-    padding-left: 0.5rem;
-}
-
-.curr-album-playing{
-    height: 4rem;
-    border-radius: 0.5rem;
-}
-
-.curr-song-name{
-    font-weight: 500;
-    font-size: 0.9rem;
-}
-
-.curr-song-artist{
-    font-size: 0.7rem;
-}
-
-.album-album-artist-name{
-    padding-left: 0.9rem;
-    line-height: 0.5rem;
-}
-
-.icon-album{
-    padding-left: 1rem;
-    font-size: 1.1rem;
-}
-
-.download-icon{
-    padding-left: 0.5rem;
-}
-
-.heart-icon{
-    transition: color 0.5s
-}
-
-.heart-icon:hover{
-    color: var(--spotify-red);
-}
-
-.player{
-    width: 50%;
-    
-}
-
-.controls{
-    width: 25%;
-    display: flex;
-    justify-content: space-evenly;
-    align-items: center;
-    cursor: default;
-}
-
-.volume{
-    width: 35%;
-    appearance: none;
-    background-color: transparent;
-    cursor: pointer;
-}
-
-.volume::-webkit-slider-runnable-track{
-    background-color: #ddd;
-    border-radius: 100px;
-    height: 0.2rem;
-    
-}
-
-.volume::-webkit-slider-thumb {
-    appearance: none;
-    height: 1rem;
-    width: 1rem;
-    background-color: #277443;
-    border-radius: 50%;
-    margin-top: -6px;
-}
-
-.player-control{
-    display: flex;
-    justify-content: center;
-    align-items: center;
-}
-
-.player-control-icon{
-    height: 1rem;
-    margin-left: 1.75rem;
-    opacity: 0.7;
-}
-
-.player-control-icon:hover{
-    opacity: 1;
-}
-
-.playback-bar{
-    display: flex;
-    justify-content: center;
-    align-items: center;
-}
-
-.progress-bar{
-    width: 70%;
-    appearance: none;
-    background-color: transparent;
-    cursor: pointer;
-}
-
-.progress-bar::-webkit-slider-runnable-track{
-    background-color: #ddd;
-    border-radius: 100px;
-    height: 0.2rem;
-}
-
-.progress-bar::-webkit-slider-thumb {
-    appearance: none;
-    height: 1rem;
-    width: 1rem;
-    background-color: #1bd760;
-    border-radius: 50%;
-    margin-top: -6px;
-}
-
-.space-btwn-playback{
-    height: 0.4rem;
-}
-
-/* Focus styles is in here */
-[role="button"]:focus,
-button:focus,
-input:focus {
-    outline: 2px solid var(--spotify-green);
-    outline-offset: 2px;
-}
-
-/* Hover effects there */
-[role="button"]:hover,
-.player-control-icon:hover {
-    opacity: 1;
-    transform: scale(1.05);
-    transition: all 0.2s ease;
-}
-
-.card:hover {
-    background-color: #2a2a2a;
-    transform: translateY(-2px);
-    transition: all 0.3s ease;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
 }


### PR DESCRIPTION
What’s New
- Added a toggle button in the top navigation bar to switch between dark and light themes.
- Defined CSS custom properties (`--bg-color`, `--text-color`, `--card-bg`) to manage theming.
- On toggle, JavaScript toggles the `light-mode` class on `<body>` and switches the icon between moon and sun.
- User preference is saved to `localStorage` so the theme persists across reloads.
 How to Test
1. Run the project (open in browser or via a local server).
2. Click the moon icon in the nav bar — UI should switch to light theme (backgrounds, text, cards update).
3. Refresh the page — the chosen theme should remain.
4. Click again to return to dark mode.

 Why This Change
- Improves UI accessibility for users preferring lighter themes.
- Adds a nice visual UX touch and personalization.

Please let me know if you’d like the toggle styled as a sliding switch instead of icon toggling — I can do that too.  
Looking forward to your review! 😊
